### PR TITLE
Fixed sorting recent matches by played column

### DIFF
--- a/public/js/playerMatches.js
+++ b/public/js/playerMatches.js
@@ -131,7 +131,12 @@ module.exports = function() {
                     data: 'start_time',
                     title: 'Played',
                     render: function(data, type, row) {
-                        return moment.unix(data + row.duration).fromNow();
+                        var timestamp = moment.unix(data + row.duration);
+                        if (type === 'sort') {
+                            return timestamp.valueOf(); // Sort by unix timestamp
+                        }
+
+                        return timestamp.fromNow();
                     }
             },
                 {


### PR DESCRIPTION
Sorting by the played column attempts to sort based on the the human readable "time from now" which will never work as expected.

This pull request changes sorting to use the unix offset instead.

I didn't set up YASP to actually see if this pull request works, so please let me know if there are any issues.