### PR TITLE
reduced homepage weight

### DIFF
--- a/public/css/yasp_home.css
+++ b/public/css/yasp_home.css
@@ -262,7 +262,7 @@ img.grayscale {
     color: #ffffff;
     padding-top: 7%;
     width: 100%;
-    background: url('../images/header.jpg') no-repeat center center fixed;
+    /*background: url('../images/header.jpg') no-repeat center center fixed;*/
     -webkit-background-size: cover;
     -moz-background-size: cover;
     -o-background-size: cover;

--- a/views/home.jade
+++ b/views/home.jade
@@ -31,16 +31,16 @@ block page_content
       paper-fab-menu-item(icon='filter-list', color='rgb(255, 127, 14);', tooltip='TL;DR', link="#content")#tldr
       paper-fab-menu-item(icon='star', color='rgb(44, 160, 44);', tooltip='Features', link="#match_statistics")#features
       paper-fab-menu-item(icon='redeem', color='red;', tooltip='We need your help!', link="#cheeses")#cheese
-  
-  #philosophy
-    .right-img
-        .container
-          .row
-            .col-md-7
-              h1(style="color:#000000;") Our Mission
-              p.lead Free Replay Parsing for All
-            .col-md-5
-  
+  //-
+    #philosophy
+      .right-img
+          .container
+            .row
+              .col-md-7
+                h1(style="color:#000000;") Our Mission
+                p.lead Free Replay Parsing for All
+              .col-md-5
+    
   #content.featurette
     .container
       .row
@@ -57,14 +57,14 @@ block page_content
           .featurette-item
             .icon-circle
               img.circle-margin(src='../public/images/barchart.png')
-            h4 Go beyond the API.
-            p We parse replays to provide statistics unavailable through the API or game client.
+            h4 In-Depth Statistics.
+            p We parse replay files to provide highly detailed match statistics.
         .col-md-4.text-center.team-text
           .featurette-item
             .icon-circle
               img.circle-margin(src='../public/images/present.png')
             h4 Free of charge.
-            p We're supported by volunteer developers and community contributions, meaning we don't need to charge users anything.
+            p We're supported by volunteer developers and donations, so we don't charge users anything.
   
   #match_statistics.callout
       .container.bottom-padding
@@ -93,17 +93,17 @@ block page_content
               #chart-gold
           .col-md-8.col-md-offset-2.text-center.bottom-padding
             h3 See <a href="/matches/#{match.match_id}/graphs" target="_blank">charts</a> of how gold, XP, and last hits changed over the game.
-
-  #positions.blurb.bright
-    .container
-      .col-md-12.text-center
-        h2 Positions
-      .col-md-8.col-md-offset-2.bottom-padding
-        hr(style="border-top: 1px solid #777;")
-      include match/positions_map
-      .col-md-8.col-md-offset-2.text-center
-        br
-        h3 See how players laned and where they warded.
+  //-
+    #positions.blurb.bright
+      .container
+        .col-md-12.text-center
+          h2 Positions
+        .col-md-8.col-md-offset-2.bottom-padding
+          hr(style="border-top: 1px solid #777;")
+        include match/positions_map
+        .col-md-8.col-md-offset-2.text-center
+          br
+          h3 See how players laned and where they warded.
   
   #cheeses.featurette.dark
     .container

--- a/views/home.jade
+++ b/views/home.jade
@@ -64,7 +64,7 @@ block page_content
             .icon-circle
               img.circle-margin(src='../public/images/present.png')
             h4 Free of charge.
-            p We're supported by volunteer developers and donations, so we don't charge users anything.
+            p Our servers are paid for by donations and development is done by volunteers, so we don't charge users anything.
   
   #match_statistics.callout
       .container.bottom-padding


### PR DESCRIPTION
Reduced bandwidth requirement for homepage by removing sections/background images.

@albertcui should review, I may have been a little heavy-handed.

Saves:
* 400KB, our mission section
* 430KB, positions map
* 400KB, details background image