### PR TITLE
Show unchanged levels without arrow

### DIFF
--- a/views/match/match_teamfights.jade
+++ b/views/match/match_teamfights.jade
@@ -102,7 +102,7 @@ block match_content
                 if player.buybacks
                  div(style="font-size:30px;") !{"&#128176;"}
               td(style="white-space: nowrap;")
-                if player.level_start != player.level_end
+                if player.level_start !== player.level_end
                   | #{player.level_start}<i class="fa fa-long-arrow-right"></i>#{player.level_end}
                 else
                   | #{player.level_start}

--- a/views/match/match_teamfights.jade
+++ b/views/match/match_teamfights.jade
@@ -101,7 +101,11 @@ block match_content
               td
                 if player.buybacks
                  div(style="font-size:30px;") !{"&#128176;"}
-              td(style="white-space: nowrap;") #{player.level_start}<i class="fa fa-long-arrow-right"></i>#{player.level_end}
+              td(style="white-space: nowrap;")
+                if player.level_start != player.level_end
+                  | #{player.level_start}<i class="fa fa-long-arrow-right"></i>#{player.level_end}
+                else
+                  | #{player.level_start}
               //td=player.deaths
               //td=player.buybacks
               td=player.damage


### PR DESCRIPTION
Currently the Teamfights page always shows levels like 9->9. Change that to just 9, but show actual changes like 9->10.