### PR TITLE
Improvements to quickstart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,15 @@ Tech
 
 Quickstart
 ----
-* Install dependencies.  If on Debian/Ubuntu: `sudo bash init.sh`  Otherwise, you're responsible for figuring out how to install dependencies yourself.
+* Install dependencies: `sudo bash init.sh`. For other platforms, please have a look at the [wiki](https://github.com/yasp-dota/yasp/wiki/Installation-for-other-platforms).
 * Create .env file with required config values in KEY=VALUE format (see config.js for a full listing of options) `cp .env_example .env`
   * Note: If you have Steam Guard activated on your account you will
     either have to deactivate it or create a new account for use with
     the retriever (recommended).
 * Build `npm run build`
-* Run all services in dev mode (this will run under nodemon so file changes automatically restart the server): `npm run dev`.  You can also start individual services: `npm run dev web,parser`
+* Run `npm test` to make sure your install works correctly
+* Run all services in dev mode (this will run under nodemon so file changes automatically restart the server): `npm run dev`. You can also start individual services.
+
 
 Sample Data
 ----

--- a/config.js
+++ b/config.js
@@ -7,7 +7,7 @@ catch(e){
 var defaults = {
     "STEAM_API_KEY": "", //for API reqs, in worker
     "STEAM_USER": "", //for getting replay salt/profile data, in retriever
-    "STEAM_PASS": "",
+    "STEAM_PASS": "", //make sure to wrap in double quotes if it contains special characters
     "RECAPTCHA_PUBLIC_KEY": "", //for preventing automated requests, in web
     "RECAPTCHA_SECRET_KEY": "",
     "PAYPAL_ID": "", //for donations, in web


### PR DESCRIPTION
I went through the process of building and running YASP on my Fedora machine. This patch adds a new init script to make it easier for anyone who tries the same thing after me. I also thought the instructions were a bit unclear in places

This also fixes an issue in the init script for Debian/Ubuntu. Since contextify (and possibly other dependencies) don't currently run under Node 4.0.0 which has recently been declared the stable version of Node (see https://github.com/brianmcd/contextify/issues/180).

For a more complete list of changes, see the comment to the commit.