### PR TITLE
Fixed application crash in /status if PostgreSQL connection is lost.

### DIFF
--- a/status.js
+++ b/status.js
@@ -5,21 +5,13 @@ module.exports = function getStatus(db, redis, queue, cb) {
         matches: function(cb) {
             //db.from('matches').count().asCallback(function(err, count) {
             db.raw("SELECT reltuples::bigint AS count FROM pg_class where relname='matches';").asCallback(function(err, count) {
-                if(err) {
-                    cb(err);
-                } else {
-                    extractCount(err, count.rows, cb);
-                }
+                extractCount(err, count, cb);
             });
         },
         players: function(cb) {
             //db.from('players').count().asCallback(function(err, count) {
             db.raw("SELECT reltuples::bigint AS count FROM pg_class where relname='players';").asCallback(function(err, count) {
-                if(err) {
-                    cb(err);
-                } else {
-                    extractCount(err, count.rows, cb);
-                }
+                extractCount(err, count, cb);
             });
         },
         user_players: function(cb) {
@@ -121,6 +113,10 @@ module.exports = function getStatus(db, redis, queue, cb) {
     function extractCount(err, count, cb) {
         if (err) {
             return cb(err);
+        }
+        // We need the property "rows" for "matches" and "players". Others just need count
+        if(count.hasOwnProperty("rows")) {
+            count = count.rows;
         }
         //psql counts are returned as [{count:'string'}].  If we want to do math with them we need to numberify them
         cb(err, Number(count[0].count));

--- a/status.js
+++ b/status.js
@@ -5,13 +5,21 @@ module.exports = function getStatus(db, redis, queue, cb) {
         matches: function(cb) {
             //db.from('matches').count().asCallback(function(err, count) {
             db.raw("SELECT reltuples::bigint AS count FROM pg_class where relname='matches';").asCallback(function(err, count) {
-                extractCount(err, count.rows, cb);
+                if(err) {
+                    cb(err);
+                } else {
+                    extractCount(err, count.rows, cb);
+                }
             });
         },
         players: function(cb) {
             //db.from('players').count().asCallback(function(err, count) {
             db.raw("SELECT reltuples::bigint AS count FROM pg_class where relname='players';").asCallback(function(err, count) {
-                extractCount(err, count.rows, cb);
+                if(err) {
+                    cb(err);
+                } else {
+                    extractCount(err, count.rows, cb);
+                }
             });
         },
         user_players: function(cb) {


### PR DESCRIPTION
yasp crashes if there is no connection to PostgreSQL. This could happen if the SQL server crashes or goes down for maintenance.

The reason is that `count` is then undefined and has no attribute `rows`.

So far the commit displays a white page with a stacktrace. Might not be the most elegant way but the player pages behave the same way. Is there an easy way to make some pretty 500 error pages from the `status` module?