### PR TITLE
track only modifiers applied to heroes

### DIFF
--- a/processExpand.js
+++ b/processExpand.js
@@ -69,9 +69,12 @@ module.exports = function processCreateParsedData(entries, meta, populate)
             //gain buff/debuff
             e.unit = e.attackername; //unit that buffed (can we use source to get the hero directly responsible? chen/enchantress/etc.)
             e.key = translate(e.inflictor); //the buff
-            //e.targetname is target of buff (possibly illusion)
-            e.type = "modifier_applied";
-            expand(e);
+            e.targetname = computeIllusionString(e.targetname, e.targetillusion); //target of buff (possibly illusion)
+            if (e.targethero && !e.targetillusion)
+            {
+                e.type = "modifier_applied";
+                expand(e);
+            }
         },
         "DOTA_COMBATLOG_MODIFIER_REMOVE": function(e)
         {
@@ -86,11 +89,11 @@ module.exports = function processCreateParsedData(entries, meta, populate)
             //kill
             e.unit = e.sourcename; //killer (a hero)
             e.key = computeIllusionString(e.targetname, e.targetillusion);
-            //count kill by this unit
-            e.type = "killed";
             //don't count denies/expires
             if (e.attackername !== e.key)
             {
+                //count kill by this unit
+                e.type = "killed";
                 expand(e);
             }
             //killed unit was a real hero

--- a/processExpand.js
+++ b/processExpand.js
@@ -72,6 +72,7 @@ module.exports = function processCreateParsedData(entries, meta, populate)
             e.targetname = computeIllusionString(e.targetname, e.targetillusion); //target of buff (possibly illusion)
             if (e.targethero && !e.targetillusion)
             {
+                //TODO only include a whitelist of modifiers
                 e.type = "modifier_applied";
                 expand(e);
             }

--- a/processExpand.js
+++ b/processExpand.js
@@ -72,9 +72,12 @@ module.exports = function processCreateParsedData(entries, meta, populate)
             e.targetname = computeIllusionString(e.targetname, e.targetillusion); //target of buff (possibly illusion)
             if (e.targethero && !e.targetillusion)
             {
-                //TODO only include a whitelist of modifiers
-                e.type = "modifier_applied";
-                expand(e);
+                var whitelist = {"modifier_item_ultimate_scepter_consumed":1};
+                if (e.key in whitelist)
+                {
+                    e.type = "modifier_applied";
+                    expand(e);
+                }
             }
         },
         "DOTA_COMBATLOG_MODIFIER_REMOVE": function(e)

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -124,11 +124,11 @@ CREATE TABLE player_matches (
   damage_inflictor json,
   runes json,
   killed_by json,
-  modifier_applied json,
   kill_streaks json,
   multi_kills json,
   healing json,
-  life_state json
+  life_state json,
+  modifier_applied json
   --disabled due to incompatibility
   --kill_streaks_log json[][], --an array of kill streak values
   --multi_kill_id_vals integer[] --an array of multi kill values (the length of each multi kill)

--- a/utility.js
+++ b/utility.js
@@ -390,8 +390,6 @@ function getParseSchema()
                 {},
                 "killed_by":
                 {},
-                "modifier_applied":
-                {},
                 "kill_streaks":
                 {},
                 "multi_kills":
@@ -399,6 +397,8 @@ function getParseSchema()
                 "healing":
                 {},
                 "life_state":
+                {},
+                "modifier_applied":
                 {},
                 /*
                 "kill_streaks_log": [], // an array of kill streak values


### PR DESCRIPTION
Set up for #815 .

It seems like the only things we care about are aghs consumed and dusts applied.

- [x] alter table player_matches drop column modifier_applied
- [ ] deploy new code
- [ ] pull and restart all instances (version mismatch)
- [ ] alter table player_matches add column modifier_applied json
