### PR TITLE
Add additional sentiment analysis values

### DIFF
--- a/compute.js
+++ b/compute.js
@@ -476,7 +476,12 @@ function renderMatch(m)
             "throw": -1,
             "salt": -1,
             "ez": -1,
-            "mad": -1
+            "mad": -1,
+            "hero": 0,
+            "gg": 1,
+            "salty": -1,
+            "autist": -1,
+            "autism": -1
         });
     }
     //create gold breakdown data

--- a/compute.js
+++ b/compute.js
@@ -478,7 +478,6 @@ function renderMatch(m)
             "ez": -1,
             "mad": -1,
             "hero": 0,
-            "gg": 1,
             "salty": -1,
             "autist": -1,
             "autism": -1


### PR DESCRIPTION
I went over the chat in my last 50 games and added a few sentiment analysis values that did not get picked up by yasp.

Individual explanations:
- "hero": positive in general language, but value neutral in the context of the game.
- "gg": self explanatory?
- "salty": if "salt" counts, this probably should count as well.
- "autist" / "autism": always negative in the context of the game.