### PR TITLE
only add players to ranker queue when ENABLE_RANKER is set in config

### DIFF
--- a/config.js
+++ b/config.js
@@ -45,6 +45,7 @@ var defaults = {
     "ENABLE_INSERT_ALL_MATCHES": "", //set to enable inserting all matches
     "ENABLE_RANDOM_MMR_UPDATE": "", //set to randomly update MMRs in ranked matches
     "ENABLE_CASSANDRA_PLAYER_CACHE": "", //set to use cassandra for player caches
+    "ENABLE_RANKER": "", //set to enable ranker queue
     //the following are deprecated
     "PARSER_HOST": "localhost:5200",
     "MONGO_URL": "mongodb://localhost/dota",

--- a/scanner.js
+++ b/scanner.js
@@ -171,7 +171,7 @@ function scanApi(seq_num)
                         },
                         "decideRank": function(cb)
                         {
-                            if (match.lobby_type === 7 && p.account_id !== constants.anonymous_account_id)
+                            if (match.lobby_type === 7 && p.account_id !== constants.anonymous_account_id && config.ENABLE_RANKER)
                             {
                                 addToQueue(rankQueue,
                                 {


### PR DESCRIPTION
on a small vps / lowmem instance the new ranker will crash redis (happened to me frequently), 
most people don't have alot of mmr data to begin with,
so the ranker shouldn't be enabled by default.