### PR TITLE
#994 - Removed min-height from hero images on the benchmark page

### DIFF
--- a/views/heroes.jade
+++ b/views/heroes.jade
@@ -40,7 +40,6 @@ block content
         .grid figure img {
         	position: relative;
         	display: block;
-        	min-height: 100%;
         	max-width: 100%;
         	opacity: 0.8;
         }


### PR DESCRIPTION
Should fix the issue in #994 
Before:
![issue 994 before](https://cloud.githubusercontent.com/assets/100885/14919867/cec04916-0df8-11e6-9dd3-17ac50f762ab.png)

After:
![issue 994 after](https://cloud.githubusercontent.com/assets/100885/14919866/cebf6d0c-0df8-11e6-832d-010c2009af9b.png)