### PR TITLE
#875 - Correctly sort match skill in match tables

### DIFF
--- a/views/mixins/match_table.jade
+++ b/views/mixins/match_table.jade
@@ -8,7 +8,7 @@ mixin match_table(matches, extended)
           th: abbr(title=tooltips.hero_id) Hero
           th: abbr(title=tooltips.result) R
           th: abbr(title=tooltips.game_mode) M
-          th: abbr(title=tooltips.skill) S
+          th.skill: abbr(title=tooltips.skill) S
           th.fromNow: abbr(title=tooltips.ended) E
           th.seconds: abbr(title=tooltips.duration) L
           th: abbr(title=tooltips.kills) K
@@ -31,7 +31,7 @@ mixin match_table(matches, extended)
                 =match.hero_id
             td(class=match.player_win ? "text-success" : "text-danger")=match.player_win ? "W" : "L"
             td.small=constants.game_mode[match.game_mode] ? constants.game_mode[match.game_mode].name : match.game_mode
-            td.small=constants.skill[match.skill] || match.skill
+            td.small=match.skill
             td.small=match.start_time+match.duration
             td.rankable=match.duration
             td.rankable=match.kills

--- a/views/player/player.jade
+++ b/views/player/player.jade
@@ -88,6 +88,22 @@ append footer_assets
         },
         columnDefs: [
             {
+                targets: "skill",
+                render: function(data, type) {
+                    var skillIDs = {
+                        1: "Normal",
+                        2: "High",
+                        3: "Very High",
+                    };
+
+                    if (type === "display") {
+                        return (data in skillIDs ? skillIDs[data] : data);
+                    }
+
+                    return data;
+                }
+            },
+            {
                 "targets": "fromNow",
                 render: function(data, type) {
                     if (type === "display") {


### PR DESCRIPTION
Fixes the sort order of the skill column in the matches table as described in issue #875.

I don't really like hard coding the skills again, but I couldn't figure out how to make the skill constants available in views/player/player.jade