### PR TITLE
#801 - Added SF shadowraze2 and shadowraze3 abilities

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -72,13 +72,24 @@ countries.forEach(function(c){
 constants.items = items;
 //abilities, already keyed by name
 var abilities = constants.abilities.abilitydata;
+
+// Add missing Shadow Fiend raze abilities by copying the shortest raze
+if (!abilities.nevermore_shadowraze2) {
+    abilities.nevermore_shadowraze2 = Object.assign({}, abilities.nevermore_shadowraze1);
+    // Find and replace short raze range with medium raze range
+    abilities.nevermore_shadowraze2.attrib = abilities.nevermore_shadowraze2.attrib.replace(/\d{3}/, 450);
+}
+if (!abilities.nevermore_shadowraze3) {
+    abilities.nevermore_shadowraze3 = Object.assign({}, abilities.nevermore_shadowraze1);
+    // Find and replace short raze range with long raze range
+    abilities.nevermore_shadowraze3.attrib = abilities.nevermore_shadowraze3.attrib.replace(/\d{3}/, 700);
+}
+
 for (var key2 in abilities)
 {
     abilities[key2].img = "/apps/dota2/images/abilities/" + key2 + "_md.png";
     abilities[key2].cmb = abilities[key2].cmb.replace("http://cdn.dota2.com", "");
 }
-abilities.nevermore_shadowraze2 = abilities.nevermore_shadowraze1;
-abilities.nevermore_shadowraze3 = abilities.nevermore_shadowraze1;
 abilities.attribute_bonus = {
     dname: "Attribute Bonus",
     img: '/public/images/Stats.png',


### PR DESCRIPTION
Fixes the issue described in #801 

I assume json/abilities.json is grabbed from Valve. If so, we'll need to make sure we keep these updates the next time the abilities file is regenerated, or we'll need a way to add/augment the these files.
Let me know what you think.