### PR TITLE
Fix an issue with the skill sorting due to a merge issue

### DIFF
--- a/views/mixins/match_table.jade
+++ b/views/mixins/match_table.jade
@@ -13,7 +13,7 @@ mixin match_table(matches)
           if q.desc
             th: abbr(title=tooltips[q.desc])=prettyPrint(q.desc)
           else
-            th: abbr(title=tooltips.skill) S
+            th.skill: abbr(title=tooltips.skill) S
             th: abbr(title=tooltips.kills) K
             th: abbr(title=tooltips.deaths) D
             th: abbr(title=tooltips.assists) A


### PR DESCRIPTION
Looks like the last merge lost some of the changes. This should fix the skills showing up as their IDs instead of English names (Normal, High, Very High).