### PR TITLE
optimization to match object transferred to parse job

### DIFF
--- a/store/buildPlayer.js
+++ b/store/buildPlayer.js
@@ -96,9 +96,8 @@ function buildPlayer(options, cb)
     queryObj = preprocessQuery(queryObj);
     //1 filter expected for account id
     var filter_exists = queryObj.filter_count > 1;
-    //choose fields to project based on tab/filter
-    //we need to project everything to build a new cache/toplist, otherwise optimize and do a subset
-    queryObj.project = config.ENABLE_PLAYER_CACHE || queryObj.keywords.desc ? everything : projections[info];
+    //choose fields to project based on tab/filter, we need to project everything to build a new cache/toplist, otherwise optimize and do a subset
+    queryObj.project = everything;
     //choose fields to aggregate based on tab
     var obj = {};
     aggs[info].forEach(function(k)

--- a/svc/parser.js
+++ b/svc/parser.js
@@ -85,27 +85,19 @@ pQueue.process(1, function(job, cb)
                 {
                     return cb(err);
                 }
-                //extend match object with parsed data, keep existing data if key conflict
-                for (var key in parsed_data)
+                parsed_data.match_id = match.match_id;
+                parsed_data.pgroup = match.pgroup;
+                parsed_data.parse_status = 2;
+                if (match.replay_blob_key)
                 {
-                    match[key] = match[key] || parsed_data[key];
+                    insertUploadedParse(parsed_data, cb);
                 }
-                //specifically overwrite players since we now have parsed data for them
-                match.players = parsed_data.players;
-                match.parse_status = 2;
+                else
+                {
+                    insertStandardParse(parsed_data, cb);
+                }
                 cb(err);
             });
-        },
-        "insertMatch": function(cb)
-        {
-            if (match.replay_blob_key)
-            {
-                insertUploadedParse(match, cb);
-            }
-            else
-            {
-                insertStandardParse(match, cb);
-            }
         },
     }, function(err)
     {

--- a/svc/parser.js
+++ b/svc/parser.js
@@ -96,7 +96,6 @@ pQueue.process(1, function(job, cb)
                 {
                     insertStandardParse(parsed_data, cb);
                 }
-                cb(err);
             });
         },
     }, function(err)

--- a/test/test.js
+++ b/test/test.js
@@ -265,6 +265,7 @@ describe("web", function()
                 done(err);
             });
         });
+        //TODO test against an unparsed match to catch exceptions caused by code expecting parsed data
         it('/matches/:valid', function(done)
         {
             supertest(app).get('/matches/1781962623').expect(200).end(function(err, res)

--- a/test/test.js
+++ b/test/test.js
@@ -13,7 +13,6 @@ config.REDIS_URL = "redis://localhost:6379/1";
 config.SESSION_SECRET = "testsecretvalue";
 config.NODE_ENV = "test";
 config.ENABLE_MATCH_CACHE = 1;
-//config.ENABLE_PLAYER_CACHE = 1;
 config.FRONTEND_PORT = 5001;
 config.PARSER_PORT = 5201;
 var async = require('async');

--- a/views/match/match_combat.jade
+++ b/views/match/match_combat.jade
@@ -47,7 +47,7 @@ block match_content
                       span="/"
                       span(class="format" class=p1>p2 ? "text-danger" : "") #{p1}
               td
-                abbr.blackunderline(title="Radiant killed "+match.hero_combat.kills.radiant+" heros.<br>Dire kiled "+match.hero_combat.kills.dire+" heroes.")
+                abbr.blackunderline(title="Radiant killed "+match.hero_combat.kills.radiant+" heroes.<br>Dire kiled "+match.hero_combat.kills.dire+" heroes.")
                     span(class="format" class=match.hero_combat.kills.radiant>match.hero_combat.kills.dire ? "text-success" : "") #{match.hero_combat.kills.radiant}
                     span="/"
                     span(class="format" class=match.hero_combat.kills.dire>match.hero_combat.kills.radiant ? "text-danger" : "") #{match.hero_combat.kills.dire}


### PR DESCRIPTION
In a recent change I made the cleaning of the object row used for db insertion return a new object, rather than deleting the extra properties (thus mutating the original object).

Previously we then used this mutated object to pass as input to the parse job, which is larger than is strictly needed and thus increases Redis usage.

With this change I am now creating a new object to pass with minimal properties (match_id, replay_blob_key, and pgroup).

In `parser`, previously we extended the match object passed as input.  Now we use the `parsed_data` object generated from the parse directly.  We add back any properties from the input we still need `match_id, pgroup`.  

After parse completion, the parser service invokes `insertMatch` again.  `insertMatch` now attempts to re-populate the hero_id field in the input object using the pgroup (because hero_id is not available from the parser).

Please review this change *carefully*.

Reviewers:
@albertcui 