### PR TITLE
add CORS header

### DIFF
--- a/public/js/actions/actions.js
+++ b/public/js/actions/actions.js
@@ -59,7 +59,7 @@ export function fetchData(name, options)
     // that is passed on as the return value of the dispatch method.
     // In this case, we return a promise to wait for.
     // This is not required by thunk middleware, but it is convenient for us.
-    return fetch(getEndpoint(name, options)).then(response => response.json()).then(json =>
+    return fetch(getEndpoint(name, options), {credentials: 'include'}).then(response => response.json()).then(json =>
       // We can dispatch many times!
       // Here, we update the app state with the results of the API call.
       dispatch(responseData(name, json)));

--- a/routes/api.js
+++ b/routes/api.js
@@ -21,7 +21,7 @@ module.exports = function(db, redis, cassandra)
 {
     api.use(function(req, res, cb)
     {
-        res.header('Access-Control-Allow-Origin', '*');
+        res.header('Access-Control-Allow-Origin', req.headers.origin || '*');
         res.header('Access-Control-Allow-Credentials', 'true');
         cb();
     });

--- a/routes/api.js
+++ b/routes/api.js
@@ -19,13 +19,11 @@ var buildStatus = require('../store/buildStatus');
 const crypto = require('crypto');
 module.exports = function(db, redis, cassandra)
 {
-    api.get('/items', function(req, res)
+    api.use(function(req, res, cb)
     {
-        res.json(constants.items[req.query.name]);
-    });
-    api.get('/abilities', function(req, res)
-    {
-        res.json(constants.abilities[req.query.name]);
+        res.header('Access-Control-Allow-Origin', '*');
+        res.header('Access-Control-Allow-Credentials', 'true');
+        cb();
     });
     api.get('/metadata', function(req, res, cb)
     {
@@ -74,6 +72,14 @@ module.exports = function(db, redis, cassandra)
             }
             res.json(result);
         });
+    });
+    api.get('/items', function(req, res)
+    {
+        res.json(constants.items[req.query.name]);
+    });
+    api.get('/abilities', function(req, res)
+    {
+        res.json(constants.abilities[req.query.name]);
     });
     api.get('/matches/:match_id/:info?', function(req, res, cb)
     {

--- a/sql/cassandra.cql
+++ b/sql/cassandra.cql
@@ -158,3 +158,7 @@ CREATE TABLE yasp.player_caches (
   parse_status text,
   skill text,
 );
+
+ALTER TABLE matches WITH compaction = { 'class' :  'LeveledCompactionStrategy'  };
+ALTER TABLE player_matches WITH compaction = { 'class' :  'LeveledCompactionStrategy'  };
+ALTER TABLE player_caches WITH compaction = { 'class' :  'LeveledCompactionStrategy'  };

--- a/svc/web.js
+++ b/svc/web.js
@@ -381,7 +381,7 @@ app.get('/search', function(req, res, cb)
                 query: req.query.q,
                 result: result
             });
-        })
+        });
     }
     else
     {


### PR DESCRIPTION
Add CORS header to API endpoints.

Allow frontend developers to be able to work with the production site data without needing to setup the entire stack locally

Reviewers:
@albertcui 
@gu3st