### PR TITLE
USE created 'yasp' keyspace

### DIFF
--- a/sql/cassandra.cql
+++ b/sql/cassandra.cql
@@ -1,5 +1,6 @@
 CREATE KEYSPACE yasp WITH REPLICATION = { 'class': 'NetworkTopologyStrategy', 'datacenter1': 1 };
-CREATE TABLE yasp.matches (
+USE yasp;
+CREATE TABLE matches (
   match_id bigint PRIMARY KEY,
   match_seq_num bigint,
   radiant_win boolean,
@@ -28,7 +29,7 @@ CREATE TABLE yasp.matches (
   pgroup text,
 );
 
-CREATE TABLE yasp.player_matches (
+CREATE TABLE player_matches (
   PRIMARY KEY(match_id, player_slot),
   match_id bigint,
   account_id bigint,
@@ -88,7 +89,7 @@ CREATE TABLE yasp.player_matches (
   life_state text,
 );
 
-CREATE TABLE yasp.player_caches (
+CREATE TABLE player_caches (
   PRIMARY KEY (account_id, match_id),
   account_id bigint,
   match_id bigint,


### PR DESCRIPTION
Got the following helpful error message when setting up Cassandra.

> <stdin>:153:InvalidRequest: code=2200 [Invalid query] message="No keyspace has been specified. USE a keyspace, or explicitly specify keyspace.tablename"

Decided to go with the keyword `USE` so we don't have to specify *yasp* everywhere in the `.cql` file.