### PR TITLE
node 6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:5.10.1
+FROM mhart/alpine-node:6.2.1
 
 # Tools
 RUN apk update && apk add git curl wget bash


### PR DESCRIPTION
- [ ] figure out why requested parses stall

Weird issue that seems to happen with Node 6.  For some reason, parses requested via webpage appear to stall at completion (replay is downloaded, presumably parsed, but apparently no 'end' event is fired), so the job never completes.

The Travis test passes, but I'm hesitant to push this to production without figuring out why.