### PR TITLE
Ranking algorithm update for Q3

### DIFF
--- a/svc/cacher.js
+++ b/svc/cacher.js
@@ -186,7 +186,7 @@ function updateRankings(match, cb)
         {
             return cb(err);
         }
-        var score = (avg && !Number.isNaN(avg)) ? Math.pow(avg, 5) / 1000000000000 : undefined;
+        var score = (avg && !Number.isNaN(avg)) ? Math.pow(avg, 6) / Math.pow(10, 18) : undefined;
         async.each(match.players, function(player, cb)
         {
             if (!player.account_id || player.account_id === constants.anonymous_account_id)

--- a/svc/cacher.js
+++ b/svc/cacher.js
@@ -186,7 +186,7 @@ function updateRankings(match, cb)
         {
             return cb(err);
         }
-        var score = (avg && !Number.isNaN(avg)) ? Math.pow(avg, 6) / Math.pow(10, 18) : undefined;
+        var score = (avg && !Number.isNaN(avg)) ? Math.pow(~~(avg/100), 6) : undefined;
         async.each(match.players, function(player, cb)
         {
             if (!player.account_id || player.account_id === constants.anonymous_account_id)


### PR DESCRIPTION
Increase weight of MMR in rankings.

Note, I rescaled the rankings to divide average match MMR by 100, then round down.  Matches with average MMR below 100 will score 0 points.

Merge shortly before the July 1 ranking reset (Q3)