### PR TITLE
GA instrumented event records the age of a match per impression

### DIFF
--- a/views/match/match.jade
+++ b/views/match/match.jade
@@ -69,3 +69,5 @@ block content
 
 append footer_assets
   script(type="text/javascript", src="//s7.addthis.com/js/300/addthis_widget.js#pubid=ra-5452f1e51eac0fc5", async="async")
+  script.
+    ga('send', 'event', 'match', 'view', 'ageOfMatch', moment().diff(moment.unix(#{match.start_time+match.duration}), 'days'));


### PR DESCRIPTION
This change is part of a broader effort to reduce server costs for Yasp. 

Currently all data is stored on SSDs within GCE and all match data is preserved indefinitely. Howard and I have been discussing the introduction of some sort of "archiving" strategy for Yasp in which very old matches are somehow moved off the SSD or their footprint is reduced by purging some of the deeper match details. This change is intended to facilitate discussion and guide the right strategy for Yasp archiving (including possible outcome to not archive anything). 

This change instruments Yasp user behavior to track the age of match data when it is viewed. Resulting data can be used to profile what match data is viewed by Yasp users segmented by the age of the match.