### PR TITLE
Added Cassandra support for Docker Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-# Does not set up Cassandra
-
 # You don't usually need to edit this file.
 # If it does not fit your personal use case, docker-compose.override.yml is a preferred way to go.
 
@@ -9,6 +7,11 @@ services:
     build:
       context: .
       dockerfile: docker/postgres.dockerfile
+    network_mode: host
+  cassandra:
+    build:
+      context: .
+      dockerfile: docker/cassandra.dockerfile
     network_mode: host
   cache:
     image: redis:3

--- a/docker/cassandra.dockerfile
+++ b/docker/cassandra.dockerfile
@@ -1,0 +1,7 @@
+FROM daerdemandt/cassandra-init-manual
+
+COPY sql /tmp/sql
+RUN cp /tmp/sql/init.cql            /docker-entrypoint-init.d/10-init.cql; \
+    cp /tmp/sql/create_tables.cql   /docker-entrypoint-init.d/20-create-tables.cql; \
+    echo 'USE yasp;' | prepend /docker-entrypoint-init.d/20-create-tables.cql
+


### PR DESCRIPTION
Cassandra is mandatory now, so docker sompose should be launching it too.

Cassandra image itself does [not](https://github.com/docker-library/cassandra/blob/c3c26f2efdb9874dc5b3717662462e8ca0b2d944/3.7/docker-entrypoint.sh) support initing itself like Postgres one [does](https://github.com/docker-library/postgres/blob/bcfa58b2f0c971ad55f541f3fb868607cd391089/9.6/docker-entrypoint.sh#L79-L87), so [wrapper image](https://github.com/Daerdemandt/cassandra-docker-init) -- that adds self-initing like in Postgres container -- is used.